### PR TITLE
Update to fix crashes

### DIFF
--- a/Jap_folklore/mapgen/overmap_terrain.json
+++ b/Jap_folklore/mapgen/overmap_terrain.json
@@ -5,7 +5,7 @@
     "name": "field",
     "sym": ".",
     "color": "brown",
-    "see_cost": 2,
+    "see_cost": "high",
     "extras": "field",
     "flags": [ "NO_ROTATE" ]
   },
@@ -15,7 +15,7 @@
     "name": "ruined structure",
     "sym": "^",
     "color": "brown",
-    "see_cost": 2,
+    "see_cost": "high",
     "flags": [ "NO_ROTATE" ]
   },
   {
@@ -24,7 +24,7 @@
 	"name": "ruined structure",
 	"sym": "^",
 	"color": "brown",
-	"see_cost": 2,
+	"see_cost": "none",
 	"flags": [ "NO_ROTATE" ]
   },
   {
@@ -33,7 +33,7 @@
     "name": "old shrine",
     "sym": "S",
     "color": "red",
-    "see_cost": 2,
+    "see_cost": "high",
     "flags": [ "NO_ROTATE" ]
   },
   {
@@ -42,7 +42,7 @@
 	"name": "old shrine",
 	"sym": "S",
 	"color": "red",
-	"see_cost": 2,
+	"see_cost": "none",
 	"flags": [ "NO_ROTATE" ]
   }
 ]

--- a/Jap_folklore/mod_tileset/mod_tileset_DPItems_and_such.json
+++ b/Jap_folklore/mod_tileset/mod_tileset_DPItems_and_such.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "mod_tileset",
-    "compatibility": [ "UNDEAD_PEOPLE_BASE", "MSX++DEAD_PEOPLE", "UNDEAD_PEOPLE" ],
+    "compatibility": [ "UNDEAD_PEOPLE_BASE", "UNDEAD_PEOPLE", "MshockRealXotto", "MSX++DEAD_PEOPLE", "MSXotto+" ],
     "tiles-new": [
       {
         "file": "mod_tileset/UndeadPeople-Items_and_such.png",

--- a/Jap_folklore/mod_tileset/mod_tileset_DPKitsune.json
+++ b/Jap_folklore/mod_tileset/mod_tileset_DPKitsune.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "mod_tileset",
-    "compatibility": [ "UNDEAD_PEOPLE_BASE", "MSX++DEAD_PEOPLE", "UNDEAD_PEOPLE" ],
+    "compatibility": [ "UNDEAD_PEOPLE_BASE", "UNDEAD_PEOPLE", "MshockRealXotto", "MSX++DEAD_PEOPLE", "MSXotto+" ],
     "tiles-new": [
       {
         "file": "mod_tileset/UndeadPeople-Kitsune.png",

--- a/Jap_folklore/mod_tileset/mod_tileset_DPYoukai.json
+++ b/Jap_folklore/mod_tileset/mod_tileset_DPYoukai.json
@@ -1,7 +1,7 @@
 [
   {
 	"type": "mod_tileset",
-	"compatibility": [ "UNDEAD_PEOPLE_BASE", "MSX++DEAD_PEOPLE", "UNDEAD_PEOPLE" ],
+	"compatibility": [ "UNDEAD_PEOPLE_BASE", "UNDEAD_PEOPLE", "MshockRealXotto", "MSX++DEAD_PEOPLE", "MSXotto+" ],
     "tiles-new": [
 	   {
 		"file": "mod_tileset/UndeadPeople-Youkai.png",

--- a/Jap_folklore/mod_tileset/mod_tileset_DPYoukai_large.json
+++ b/Jap_folklore/mod_tileset/mod_tileset_DPYoukai_large.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "mod_tileset",
-    "compatibility": [ "UNDEAD_PEOPLE_BASE", "MSX++DEAD_PEOPLE", "UNDEAD_PEOPLE" ],
+    "compatibility": [ "UNDEAD_PEOPLE_BASE", "UNDEAD_PEOPLE", "MshockRealXotto", "MSX++DEAD_PEOPLE", "MSXotto+" ],
     "tiles-new": [
 	  {
 		"file": "mod_tileset/UndeadPeople-Youkai_large.png",

--- a/Jap_folklore/monsters/kitsune_monsters.json
+++ b/Jap_folklore/monsters/kitsune_monsters.json
@@ -68,8 +68,7 @@
     "harvest": "mammal_tiny",
     "death_drops": "threetail_pearl",
     "special_attacks": [
-      { "type": "spell", "spell_data": { "id": "obfuscated_body", "min_level": 1 }, "cooldown": 7 },
-      { "type": "spell", "spell_data": { "id": "summon_foxfire", "min_level": 1 }, "cooldown": 9 }
+      { "type": "spell", "spell_data": { "id": "obfuscated_body", "min_level": 1 }, "cooldown": 7 }
     ],
     "anger_triggers": [ "FRIEND_ATTACKED", "FRIEND_DIED" ],
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
@@ -104,9 +103,7 @@
     "harvest": "mammal_tiny",
     "death_drops": "fourtail_pearl",
     "special_attacks": [
-      { "type": "spell", "spell_data": { "id": "obfuscated_body", "min_level": 2 }, "cooldown": 6 },
-      { "type": "spell", "spell_data": { "id": "summon_foxfire", "min_level": 1 }, "cooldown": 8 },
-      { "type": "spell", "spell_data": { "id": "kitsune_firebolt", "min_level": 1 }, "cooldown": 10 }
+      { "type": "spell", "spell_data": { "id": "obfuscated_body", "min_level": 2 }, "cooldown": 6 }
     ],
     "anger_triggers": [ "FRIEND_ATTACKED", "FRIEND_DIED" ],
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
@@ -141,10 +138,7 @@
     "harvest": "mammal_tiny",
     "death_drops": "fivetail_pearl",
     "special_attacks": [
-      { "type": "spell", "spell_data": { "id": "obfuscated_body", "min_level": 2 }, "cooldown": 5 },
-      { "type": "spell", "spell_data": { "id": "summon_foxfire", "min_level": 2 }, "cooldown": 7 },
-      { "type": "spell", "spell_data": { "id": "kitsune_firebolt", "min_level": 1 }, "cooldown": 9 },
-      { "type": "spell", "spell_data": { "id": "mon_kitsune_escape", "min_level": 1 }, "cooldown": 11 }
+      { "type": "spell", "spell_data": { "id": "obfuscated_body", "min_level": 2 }, "cooldown": 5 }
     ],
     "anger_triggers": [ "FRIEND_ATTACKED", "FRIEND_DIED" ],
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],

--- a/Jap_folklore/recipes.json
+++ b/Jap_folklore/recipes.json
@@ -290,7 +290,7 @@
     "proficiencies": [
       { "proficiency": "prof_metalworking" }
     ],
-    "components": [ [ [ "eggs_any_shape", 1, "LIST" ], [ [ "glass_shard", 5 ] ], [ [ "chilly-p", 5 ], [ "pepper", 5 ], [ "mustard_powder", 5 ] ] ],
+    "components": [ [ [ "eggs_any_shape", 1, "LIST" ] ], [ [ "glass_shard", 5 ] ], [ [ "chilly-p", 5 ], [ "pepper", 5 ], [ "mustard_powder", 5 ] ] ],
     "qualities": [ { "id": "FINE_GRIND", "level": 1 } ]
   },
   {

--- a/Jap_folklore/recipes.json
+++ b/Jap_folklore/recipes.json
@@ -290,7 +290,7 @@
     "proficiencies": [
       { "proficiency": "prof_metalworking" }
     ],
-    "components": [ [ [ "egg_bird", 1 ], [ "egg_chicken", 1 ], [ "egg_bird_unfert", 1], [ "egg_grouse", 1 ], [ "egg_crow", 1 ], [ "egg_raven", 1 ], [ "egg_duck", 1 ], [ "egg_goose_canadian", 1 ], [ "egg_turkey", 1 ] ], [ [ "glass_shard", 5 ] ], [ [ "chilly-p", 5 ], [ "pepper", 5 ], [ "mustard_powder", 5 ] ] ],
+    "components": [ [ [ "eggs_any_shape", 1, "LIST" ], [ [ "glass_shard", 5 ] ], [ [ "chilly-p", 5 ], [ "pepper", 5 ], [ "mustard_powder", 5 ] ] ],
     "qualities": [ { "id": "FINE_GRIND", "level": 1 } ]
   },
   {


### PR DESCRIPTION
Various updates made to prevent crashes on world load/creation.

- Syntax in overworld terrain gen updated to use the new see_cost system, resolves crash
- recipe for the blinding egg updated to use "eggs_any_shape" rather than individually listing all bird eggs, resolves crash
- most special spell attacks removed from monster kitsune as they didn't seem to work properly and caused errors on world load.