### PR TITLE
NPC fixes

### DIFF
--- a/Jap_folklore/items/items.json
+++ b/Jap_folklore/items/items.json
@@ -158,7 +158,6 @@
     "material": [ "veggy" ],
     "primary_material": "dried_vegetable",
     "volume": "250 ml",
-    "milling": { "into": "flour_wheat_free", "recipe": "flour_wheat_free_mill_1_4" },
     "cooks_like": "rice_cooked",
     "flags": [ "EDIBLE_FROZEN" ],
     "vitamins": [ [ "iron", 3 ], [ "divinity", 4] ],

--- a/Jap_folklore/npc/NC_KAMI.json
+++ b/Jap_folklore/npc/NC_KAMI.json
@@ -30,10 +30,19 @@
 	},
 	{
 		"type": "item_group",
+		"id": "dry_divine_rice_bag",
+		"subtype": "collection",
+		"container-item": "bag_canvas_small",
+		"entries": [
+			{ "item": "dry_divine_rice", "container-item": "null", "count": 4, "prob": 100 } 
+		]
+	},
+	{
+		"type": "item_group",
 		"id": "kami_shopkeeper_itemgroup1",
 		"subtype": "collection",
 		"entries": [
-			{ "item": "dry_divine_rice", "count": [ 1, 5 ], "prob": 100 },
+			{ "group": "dry_divine_rice_bag", "count": [ 1, 5 ], "prob": 100 },
 			{ "item": "magatama", "count": [ 5, 10 ], "prob": 100 },
 			{ "item": "magatama_string", "count": [ 1, 5 ], "prob": 100 },
 			{ "item": "star_pearl", "count": [ 1, 6 ], "prob": 100 },

--- a/Jap_folklore/npc/npc_class.json
+++ b/Jap_folklore/npc/npc_class.json
@@ -18,7 +18,7 @@
 		"carry_override": "NC_KAMI_carried",
 		"weapon_override": "NC_KAMI_weapon",
 		"shopkeeper_item_group": [
-			{ "group": "kami_shopkeeper_itemgroup1" }
+			{ "group": "kami_shopkeeper_itemgroup1", "rigid": true }
 		]
 	}
 ]


### PR DESCRIPTION
Fixed a few things regarding NPCs
Tesuto Kami's stock has been fixed, now all stock items should properly spawn rather than just one bag of rice.
When divine rice spawns in the shrine as stock, the available bags are now full rather than just being a quarter full.
The milling recipe for divine rice has temporarily been removed due to hard crash when trying to debug spawn it in.